### PR TITLE
Update image and disk sizes to accommodate new base container image

### DIFF
--- a/integration/create_test.go
+++ b/integration/create_test.go
@@ -245,8 +245,8 @@ var _ = Describe("Create", func() {
 
 		BeforeEach(func() {
 			imageURI = pathToOCIURI(filepath.Join(ociImagesDir, "regularfile"))
-			//NOTE: this is for 1709 version of container image
-			baseImageSizeBytes = 203295012 + 100010759 + 983964
+			//NOTE: this is for 1809 version of container image
+			baseImageSizeBytes = 357317051
 			diskLimitSizeBytes = baseImageSizeBytes + 50*1024*1024
 			remainingQuota = diskLimitSizeBytes - baseImageSizeBytes
 		})
@@ -291,8 +291,8 @@ var _ = Describe("Create", func() {
 			It("does not count the base image size against the limit", func() {
 				output, err := exec.Command("dirquota", "quota", "list", fmt.Sprintf("/Path:%s", volumeMountDir)).CombinedOutput()
 				Expect(err).NotTo(HaveOccurred(), string(output))
-				//NOTE: this is for 1709 version of container image
-				Expect(string(output)).To(MatchRegexp(`Limit:\s*340.20 MB \(Hard\)`))
+				//NOTE: this is for 1809 version of container image
+				Expect(string(output)).To(MatchRegexp(`Limit:\s*390.77 MB \(Hard\)`))
 			})
 
 			It("doesn't allow files larger than remaining quota to be created", func() {

--- a/integration/stats_test.go
+++ b/integration/stats_test.go
@@ -13,9 +13,9 @@ import (
 
 var _ = Describe("Stats", func() {
 	const (
-		//NOTE: this is for 1709 version of container image
-		baseImageSizeBytes = (203295012 + 100010759 + 983964)
-		diskLimitSizeBytes = int64(350 * 1024 * 1024)
+		//NOTE: this is for 1809 version of container image
+		baseImageSizeBytes = 357317051
+		diskLimitSizeBytes = int64(500 * 1024 * 1024)
 		fileSize           = int64(30 * 1024 * 1024)
 	)
 


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
windows/nanoserver:1709 is outdated and out of support.  The Windows workers on our pipelines can't use it any more, so an upgrade to 1809 is necessary.  Tests will need to be updated in a fast-follow PR.


Backward Compatibility
---------------
Breaking Change? **Yes**