### PR TITLE
Move dockerfiles to wg-app-runtime-platform-ci repo

### DIFF
--- a/integration/fixtures/dockerfiles/Link.Dockerfile
+++ b/integration/fixtures/dockerfiles/Link.Dockerfile
@@ -1,8 +1,0 @@
-FROM microsoft/nanoserver:1709
-
-USER Administrator
-RUN mkdir C:\temp\test & echo hello > C:\temp\test\hello
-RUN mklink C:\temp\symlinkfile C:\temp\test\hello
-RUN mklink /H C:\temp\hardlinkfile C:\temp\test\hello
-RUN mklink /D C:\temp\symlinkdir C:\temp\test
-RUN mklink /J C:\temp\junctiondir C:\temp\test

--- a/integration/fixtures/dockerfiles/RegularFile.Dockerfile
+++ b/integration/fixtures/dockerfiles/RegularFile.Dockerfile
@@ -1,3 +1,0 @@
-FROM microsoft/nanoserver:1709
-
-RUN mkdir C:\temp\test & echo hello > C:\temp\test\hello

--- a/integration/fixtures/dockerfiles/ServerCore.Dockerfile
+++ b/integration/fixtures/dockerfiles/ServerCore.Dockerfile
@@ -1,3 +1,0 @@
-FROM microsoft/windowsservercore:1709
-
-RUN mkdir C:\temp\test & echo hello > C:\temp\test\hello

--- a/integration/fixtures/dockerfiles/Whiteout.Dockerfile
+++ b/integration/fixtures/dockerfiles/Whiteout.Dockerfile
@@ -1,6 +1,0 @@
-FROM microsoft/nanoserver:1709
-
-RUN mkdir C:\temp\test & echo hello > C:\temp\test\hello
-RUN del /f C:\temp\test\hello
-
-RUN echo hello2 > C:\temp\test\hello2


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
These have been moved to the Working Group CI repo for centralization and ease of updates.


Backward Compatibility
---------------
Breaking Change? **No**