### PR TITLE
Update groot-windows integration tests for new groot-windows-test image size

### DIFF
--- a/integration/create_test.go
+++ b/integration/create_test.go
@@ -246,7 +246,7 @@ var _ = Describe("Create", func() {
 		BeforeEach(func() {
 			imageURI = pathToOCIURI(filepath.Join(ociImagesDir, "regularfile"))
 			//NOTE: this is for 1809 version of container image
-			baseImageSizeBytes = 357317051
+			baseImageSizeBytes = 357381547
 			diskLimitSizeBytes = baseImageSizeBytes + 50*1024*1024
 			remainingQuota = diskLimitSizeBytes - baseImageSizeBytes
 		})
@@ -261,7 +261,7 @@ var _ = Describe("Create", func() {
 				It("counts the base image size gainst the limit", func() {
 					output, err := exec.Command("dirquota", "quota", "list", fmt.Sprintf("/Path:%s", volumeMountDir)).CombinedOutput()
 					Expect(err).NotTo(HaveOccurred(), string(output))
-					Expect(string(output)).To(MatchRegexp(`Limit:\s*50.02 MB \(Hard\)`))
+					Expect(string(output)).To(MatchRegexp(`Limit:\s*50.01 MB \(Hard\)`))
 				})
 
 				It("doesn't allow files larger than remaining quota to be created", func() {
@@ -292,7 +292,7 @@ var _ = Describe("Create", func() {
 				output, err := exec.Command("dirquota", "quota", "list", fmt.Sprintf("/Path:%s", volumeMountDir)).CombinedOutput()
 				Expect(err).NotTo(HaveOccurred(), string(output))
 				//NOTE: this is for 1809 version of container image
-				Expect(string(output)).To(MatchRegexp(`Limit:\s*390.77 MB \(Hard\)`))
+				Expect(string(output)).To(MatchRegexp(`Limit:\s*390.84 MB \(Hard\)`))
 			})
 
 			It("doesn't allow files larger than remaining quota to be created", func() {

--- a/integration/stats_test.go
+++ b/integration/stats_test.go
@@ -14,7 +14,7 @@ import (
 var _ = Describe("Stats", func() {
 	const (
 		//NOTE: this is for 1809 version of container image
-		baseImageSizeBytes = 357317051
+		baseImageSizeBytes = 357381547
 		diskLimitSizeBytes = int64(500 * 1024 * 1024)
 		fileSize           = int64(30 * 1024 * 1024)
 	)


### PR DESCRIPTION

- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
The image was rebuilt + its size is slightly different, causing failures in tests checking the size of images created/pulled.

Backward Compatibility
---------------
Breaking Change? no
