### PR TITLE
Write mutated files for when pulling down images

### DIFF
--- a/driver/driver.go
+++ b/driver/driver.go
@@ -17,7 +17,7 @@ type TarStreamer interface {
 	SetReader(io.Reader)
 	Next() (*tar.Header, error)
 	FileInfoFromHeader(*tar.Header) (string, int64, *winio.FileBasicInfo, error)
-	WriteBackupStreamFromTarFile(io.Writer, *tar.Header) (*tar.Header, error)
+	WriteBackupStreamFromTarFile(io.Writer, *tar.Header, string) (*tar.Header, error)
 }
 
 //go:generate counterfeiter -o fakes/hcs_client.go --fake-name HCSClient . HCSClient

--- a/driver/fakes/hcs_client.go
+++ b/driver/fakes/hcs_client.go
@@ -10,21 +10,6 @@ import (
 )
 
 type HCSClient struct {
-	NewLayerWriterStub        func(hcsshim.DriverInfo, string, []string) (hcs.LayerWriter, error)
-	newLayerWriterMutex       sync.RWMutex
-	newLayerWriterArgsForCall []struct {
-		arg1 hcsshim.DriverInfo
-		arg2 string
-		arg3 []string
-	}
-	newLayerWriterReturns struct {
-		result1 hcs.LayerWriter
-		result2 error
-	}
-	newLayerWriterReturnsOnCall map[int]struct {
-		result1 hcs.LayerWriter
-		result2 error
-	}
 	CreateLayerStub        func(hcsshim.DriverInfo, string, []string) error
 	createLayerMutex       sync.RWMutex
 	createLayerArgsForCall []struct {
@@ -38,19 +23,17 @@ type HCSClient struct {
 	createLayerReturnsOnCall map[int]struct {
 		result1 error
 	}
-	LayerExistsStub        func(hcsshim.DriverInfo, string) (bool, error)
-	layerExistsMutex       sync.RWMutex
-	layerExistsArgsForCall []struct {
+	DestroyLayerStub        func(hcsshim.DriverInfo, string) error
+	destroyLayerMutex       sync.RWMutex
+	destroyLayerArgsForCall []struct {
 		arg1 hcsshim.DriverInfo
 		arg2 string
 	}
-	layerExistsReturns struct {
-		result1 bool
-		result2 error
+	destroyLayerReturns struct {
+		result1 error
 	}
-	layerExistsReturnsOnCall map[int]struct {
-		result1 bool
-		result2 error
+	destroyLayerReturnsOnCall map[int]struct {
+		result1 error
 	}
 	GetLayerMountPathStub        func(hcsshim.DriverInfo, string) (string, error)
 	getLayerMountPathMutex       sync.RWMutex
@@ -66,78 +49,37 @@ type HCSClient struct {
 		result1 string
 		result2 error
 	}
-	DestroyLayerStub        func(hcsshim.DriverInfo, string) error
-	destroyLayerMutex       sync.RWMutex
-	destroyLayerArgsForCall []struct {
+	LayerExistsStub        func(hcsshim.DriverInfo, string) (bool, error)
+	layerExistsMutex       sync.RWMutex
+	layerExistsArgsForCall []struct {
 		arg1 hcsshim.DriverInfo
 		arg2 string
 	}
-	destroyLayerReturns struct {
-		result1 error
+	layerExistsReturns struct {
+		result1 bool
+		result2 error
 	}
-	destroyLayerReturnsOnCall map[int]struct {
-		result1 error
+	layerExistsReturnsOnCall map[int]struct {
+		result1 bool
+		result2 error
 	}
-	invocations      map[string][][]interface{}
-	invocationsMutex sync.RWMutex
-}
-
-func (fake *HCSClient) NewLayerWriter(arg1 hcsshim.DriverInfo, arg2 string, arg3 []string) (hcs.LayerWriter, error) {
-	var arg3Copy []string
-	if arg3 != nil {
-		arg3Copy = make([]string, len(arg3))
-		copy(arg3Copy, arg3)
-	}
-	fake.newLayerWriterMutex.Lock()
-	ret, specificReturn := fake.newLayerWriterReturnsOnCall[len(fake.newLayerWriterArgsForCall)]
-	fake.newLayerWriterArgsForCall = append(fake.newLayerWriterArgsForCall, struct {
+	NewLayerWriterStub        func(hcsshim.DriverInfo, string, []string) (hcs.LayerWriter, error)
+	newLayerWriterMutex       sync.RWMutex
+	newLayerWriterArgsForCall []struct {
 		arg1 hcsshim.DriverInfo
 		arg2 string
 		arg3 []string
-	}{arg1, arg2, arg3Copy})
-	fake.recordInvocation("NewLayerWriter", []interface{}{arg1, arg2, arg3Copy})
-	fake.newLayerWriterMutex.Unlock()
-	if fake.NewLayerWriterStub != nil {
-		return fake.NewLayerWriterStub(arg1, arg2, arg3)
 	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	return fake.newLayerWriterReturns.result1, fake.newLayerWriterReturns.result2
-}
-
-func (fake *HCSClient) NewLayerWriterCallCount() int {
-	fake.newLayerWriterMutex.RLock()
-	defer fake.newLayerWriterMutex.RUnlock()
-	return len(fake.newLayerWriterArgsForCall)
-}
-
-func (fake *HCSClient) NewLayerWriterArgsForCall(i int) (hcsshim.DriverInfo, string, []string) {
-	fake.newLayerWriterMutex.RLock()
-	defer fake.newLayerWriterMutex.RUnlock()
-	return fake.newLayerWriterArgsForCall[i].arg1, fake.newLayerWriterArgsForCall[i].arg2, fake.newLayerWriterArgsForCall[i].arg3
-}
-
-func (fake *HCSClient) NewLayerWriterReturns(result1 hcs.LayerWriter, result2 error) {
-	fake.NewLayerWriterStub = nil
-	fake.newLayerWriterReturns = struct {
+	newLayerWriterReturns struct {
 		result1 hcs.LayerWriter
 		result2 error
-	}{result1, result2}
-}
-
-func (fake *HCSClient) NewLayerWriterReturnsOnCall(i int, result1 hcs.LayerWriter, result2 error) {
-	fake.NewLayerWriterStub = nil
-	if fake.newLayerWriterReturnsOnCall == nil {
-		fake.newLayerWriterReturnsOnCall = make(map[int]struct {
-			result1 hcs.LayerWriter
-			result2 error
-		})
 	}
-	fake.newLayerWriterReturnsOnCall[i] = struct {
+	newLayerWriterReturnsOnCall map[int]struct {
 		result1 hcs.LayerWriter
 		result2 error
-	}{result1, result2}
+	}
+	invocations      map[string][][]interface{}
+	invocationsMutex sync.RWMutex
 }
 
 func (fake *HCSClient) CreateLayer(arg1 hcsshim.DriverInfo, arg2 string, arg3 []string) error {
@@ -153,15 +95,17 @@ func (fake *HCSClient) CreateLayer(arg1 hcsshim.DriverInfo, arg2 string, arg3 []
 		arg2 string
 		arg3 []string
 	}{arg1, arg2, arg3Copy})
+	stub := fake.CreateLayerStub
+	fakeReturns := fake.createLayerReturns
 	fake.recordInvocation("CreateLayer", []interface{}{arg1, arg2, arg3Copy})
 	fake.createLayerMutex.Unlock()
-	if fake.CreateLayerStub != nil {
-		return fake.CreateLayerStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	return fake.createLayerReturns.result1
+	return fakeReturns.result1
 }
 
 func (fake *HCSClient) CreateLayerCallCount() int {
@@ -170,13 +114,22 @@ func (fake *HCSClient) CreateLayerCallCount() int {
 	return len(fake.createLayerArgsForCall)
 }
 
+func (fake *HCSClient) CreateLayerCalls(stub func(hcsshim.DriverInfo, string, []string) error) {
+	fake.createLayerMutex.Lock()
+	defer fake.createLayerMutex.Unlock()
+	fake.CreateLayerStub = stub
+}
+
 func (fake *HCSClient) CreateLayerArgsForCall(i int) (hcsshim.DriverInfo, string, []string) {
 	fake.createLayerMutex.RLock()
 	defer fake.createLayerMutex.RUnlock()
-	return fake.createLayerArgsForCall[i].arg1, fake.createLayerArgsForCall[i].arg2, fake.createLayerArgsForCall[i].arg3
+	argsForCall := fake.createLayerArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *HCSClient) CreateLayerReturns(result1 error) {
+	fake.createLayerMutex.Lock()
+	defer fake.createLayerMutex.Unlock()
 	fake.CreateLayerStub = nil
 	fake.createLayerReturns = struct {
 		result1 error
@@ -184,6 +137,8 @@ func (fake *HCSClient) CreateLayerReturns(result1 error) {
 }
 
 func (fake *HCSClient) CreateLayerReturnsOnCall(i int, result1 error) {
+	fake.createLayerMutex.Lock()
+	defer fake.createLayerMutex.Unlock()
 	fake.CreateLayerStub = nil
 	if fake.createLayerReturnsOnCall == nil {
 		fake.createLayerReturnsOnCall = make(map[int]struct {
@@ -195,56 +150,66 @@ func (fake *HCSClient) CreateLayerReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *HCSClient) LayerExists(arg1 hcsshim.DriverInfo, arg2 string) (bool, error) {
-	fake.layerExistsMutex.Lock()
-	ret, specificReturn := fake.layerExistsReturnsOnCall[len(fake.layerExistsArgsForCall)]
-	fake.layerExistsArgsForCall = append(fake.layerExistsArgsForCall, struct {
+func (fake *HCSClient) DestroyLayer(arg1 hcsshim.DriverInfo, arg2 string) error {
+	fake.destroyLayerMutex.Lock()
+	ret, specificReturn := fake.destroyLayerReturnsOnCall[len(fake.destroyLayerArgsForCall)]
+	fake.destroyLayerArgsForCall = append(fake.destroyLayerArgsForCall, struct {
 		arg1 hcsshim.DriverInfo
 		arg2 string
 	}{arg1, arg2})
-	fake.recordInvocation("LayerExists", []interface{}{arg1, arg2})
-	fake.layerExistsMutex.Unlock()
-	if fake.LayerExistsStub != nil {
-		return fake.LayerExistsStub(arg1, arg2)
+	stub := fake.DestroyLayerStub
+	fakeReturns := fake.destroyLayerReturns
+	fake.recordInvocation("DestroyLayer", []interface{}{arg1, arg2})
+	fake.destroyLayerMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
-		return ret.result1, ret.result2
+		return ret.result1
 	}
-	return fake.layerExistsReturns.result1, fake.layerExistsReturns.result2
+	return fakeReturns.result1
 }
 
-func (fake *HCSClient) LayerExistsCallCount() int {
-	fake.layerExistsMutex.RLock()
-	defer fake.layerExistsMutex.RUnlock()
-	return len(fake.layerExistsArgsForCall)
+func (fake *HCSClient) DestroyLayerCallCount() int {
+	fake.destroyLayerMutex.RLock()
+	defer fake.destroyLayerMutex.RUnlock()
+	return len(fake.destroyLayerArgsForCall)
 }
 
-func (fake *HCSClient) LayerExistsArgsForCall(i int) (hcsshim.DriverInfo, string) {
-	fake.layerExistsMutex.RLock()
-	defer fake.layerExistsMutex.RUnlock()
-	return fake.layerExistsArgsForCall[i].arg1, fake.layerExistsArgsForCall[i].arg2
+func (fake *HCSClient) DestroyLayerCalls(stub func(hcsshim.DriverInfo, string) error) {
+	fake.destroyLayerMutex.Lock()
+	defer fake.destroyLayerMutex.Unlock()
+	fake.DestroyLayerStub = stub
 }
 
-func (fake *HCSClient) LayerExistsReturns(result1 bool, result2 error) {
-	fake.LayerExistsStub = nil
-	fake.layerExistsReturns = struct {
-		result1 bool
-		result2 error
-	}{result1, result2}
+func (fake *HCSClient) DestroyLayerArgsForCall(i int) (hcsshim.DriverInfo, string) {
+	fake.destroyLayerMutex.RLock()
+	defer fake.destroyLayerMutex.RUnlock()
+	argsForCall := fake.destroyLayerArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *HCSClient) LayerExistsReturnsOnCall(i int, result1 bool, result2 error) {
-	fake.LayerExistsStub = nil
-	if fake.layerExistsReturnsOnCall == nil {
-		fake.layerExistsReturnsOnCall = make(map[int]struct {
-			result1 bool
-			result2 error
+func (fake *HCSClient) DestroyLayerReturns(result1 error) {
+	fake.destroyLayerMutex.Lock()
+	defer fake.destroyLayerMutex.Unlock()
+	fake.DestroyLayerStub = nil
+	fake.destroyLayerReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *HCSClient) DestroyLayerReturnsOnCall(i int, result1 error) {
+	fake.destroyLayerMutex.Lock()
+	defer fake.destroyLayerMutex.Unlock()
+	fake.DestroyLayerStub = nil
+	if fake.destroyLayerReturnsOnCall == nil {
+		fake.destroyLayerReturnsOnCall = make(map[int]struct {
+			result1 error
 		})
 	}
-	fake.layerExistsReturnsOnCall[i] = struct {
-		result1 bool
-		result2 error
-	}{result1, result2}
+	fake.destroyLayerReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
 }
 
 func (fake *HCSClient) GetLayerMountPath(arg1 hcsshim.DriverInfo, arg2 string) (string, error) {
@@ -254,15 +219,17 @@ func (fake *HCSClient) GetLayerMountPath(arg1 hcsshim.DriverInfo, arg2 string) (
 		arg1 hcsshim.DriverInfo
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.GetLayerMountPathStub
+	fakeReturns := fake.getLayerMountPathReturns
 	fake.recordInvocation("GetLayerMountPath", []interface{}{arg1, arg2})
 	fake.getLayerMountPathMutex.Unlock()
-	if fake.GetLayerMountPathStub != nil {
-		return fake.GetLayerMountPathStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.getLayerMountPathReturns.result1, fake.getLayerMountPathReturns.result2
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *HCSClient) GetLayerMountPathCallCount() int {
@@ -271,13 +238,22 @@ func (fake *HCSClient) GetLayerMountPathCallCount() int {
 	return len(fake.getLayerMountPathArgsForCall)
 }
 
+func (fake *HCSClient) GetLayerMountPathCalls(stub func(hcsshim.DriverInfo, string) (string, error)) {
+	fake.getLayerMountPathMutex.Lock()
+	defer fake.getLayerMountPathMutex.Unlock()
+	fake.GetLayerMountPathStub = stub
+}
+
 func (fake *HCSClient) GetLayerMountPathArgsForCall(i int) (hcsshim.DriverInfo, string) {
 	fake.getLayerMountPathMutex.RLock()
 	defer fake.getLayerMountPathMutex.RUnlock()
-	return fake.getLayerMountPathArgsForCall[i].arg1, fake.getLayerMountPathArgsForCall[i].arg2
+	argsForCall := fake.getLayerMountPathArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *HCSClient) GetLayerMountPathReturns(result1 string, result2 error) {
+	fake.getLayerMountPathMutex.Lock()
+	defer fake.getLayerMountPathMutex.Unlock()
 	fake.GetLayerMountPathStub = nil
 	fake.getLayerMountPathReturns = struct {
 		result1 string
@@ -286,6 +262,8 @@ func (fake *HCSClient) GetLayerMountPathReturns(result1 string, result2 error) {
 }
 
 func (fake *HCSClient) GetLayerMountPathReturnsOnCall(i int, result1 string, result2 error) {
+	fake.getLayerMountPathMutex.Lock()
+	defer fake.getLayerMountPathMutex.Unlock()
 	fake.GetLayerMountPathStub = nil
 	if fake.getLayerMountPathReturnsOnCall == nil {
 		fake.getLayerMountPathReturnsOnCall = make(map[int]struct {
@@ -299,68 +277,155 @@ func (fake *HCSClient) GetLayerMountPathReturnsOnCall(i int, result1 string, res
 	}{result1, result2}
 }
 
-func (fake *HCSClient) DestroyLayer(arg1 hcsshim.DriverInfo, arg2 string) error {
-	fake.destroyLayerMutex.Lock()
-	ret, specificReturn := fake.destroyLayerReturnsOnCall[len(fake.destroyLayerArgsForCall)]
-	fake.destroyLayerArgsForCall = append(fake.destroyLayerArgsForCall, struct {
+func (fake *HCSClient) LayerExists(arg1 hcsshim.DriverInfo, arg2 string) (bool, error) {
+	fake.layerExistsMutex.Lock()
+	ret, specificReturn := fake.layerExistsReturnsOnCall[len(fake.layerExistsArgsForCall)]
+	fake.layerExistsArgsForCall = append(fake.layerExistsArgsForCall, struct {
 		arg1 hcsshim.DriverInfo
 		arg2 string
 	}{arg1, arg2})
-	fake.recordInvocation("DestroyLayer", []interface{}{arg1, arg2})
-	fake.destroyLayerMutex.Unlock()
-	if fake.DestroyLayerStub != nil {
-		return fake.DestroyLayerStub(arg1, arg2)
+	stub := fake.LayerExistsStub
+	fakeReturns := fake.layerExistsReturns
+	fake.recordInvocation("LayerExists", []interface{}{arg1, arg2})
+	fake.layerExistsMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
-		return ret.result1
+		return ret.result1, ret.result2
 	}
-	return fake.destroyLayerReturns.result1
+	return fakeReturns.result1, fakeReturns.result2
 }
 
-func (fake *HCSClient) DestroyLayerCallCount() int {
-	fake.destroyLayerMutex.RLock()
-	defer fake.destroyLayerMutex.RUnlock()
-	return len(fake.destroyLayerArgsForCall)
+func (fake *HCSClient) LayerExistsCallCount() int {
+	fake.layerExistsMutex.RLock()
+	defer fake.layerExistsMutex.RUnlock()
+	return len(fake.layerExistsArgsForCall)
 }
 
-func (fake *HCSClient) DestroyLayerArgsForCall(i int) (hcsshim.DriverInfo, string) {
-	fake.destroyLayerMutex.RLock()
-	defer fake.destroyLayerMutex.RUnlock()
-	return fake.destroyLayerArgsForCall[i].arg1, fake.destroyLayerArgsForCall[i].arg2
+func (fake *HCSClient) LayerExistsCalls(stub func(hcsshim.DriverInfo, string) (bool, error)) {
+	fake.layerExistsMutex.Lock()
+	defer fake.layerExistsMutex.Unlock()
+	fake.LayerExistsStub = stub
 }
 
-func (fake *HCSClient) DestroyLayerReturns(result1 error) {
-	fake.DestroyLayerStub = nil
-	fake.destroyLayerReturns = struct {
-		result1 error
-	}{result1}
+func (fake *HCSClient) LayerExistsArgsForCall(i int) (hcsshim.DriverInfo, string) {
+	fake.layerExistsMutex.RLock()
+	defer fake.layerExistsMutex.RUnlock()
+	argsForCall := fake.layerExistsArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *HCSClient) DestroyLayerReturnsOnCall(i int, result1 error) {
-	fake.DestroyLayerStub = nil
-	if fake.destroyLayerReturnsOnCall == nil {
-		fake.destroyLayerReturnsOnCall = make(map[int]struct {
-			result1 error
+func (fake *HCSClient) LayerExistsReturns(result1 bool, result2 error) {
+	fake.layerExistsMutex.Lock()
+	defer fake.layerExistsMutex.Unlock()
+	fake.LayerExistsStub = nil
+	fake.layerExistsReturns = struct {
+		result1 bool
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *HCSClient) LayerExistsReturnsOnCall(i int, result1 bool, result2 error) {
+	fake.layerExistsMutex.Lock()
+	defer fake.layerExistsMutex.Unlock()
+	fake.LayerExistsStub = nil
+	if fake.layerExistsReturnsOnCall == nil {
+		fake.layerExistsReturnsOnCall = make(map[int]struct {
+			result1 bool
+			result2 error
 		})
 	}
-	fake.destroyLayerReturnsOnCall[i] = struct {
-		result1 error
-	}{result1}
+	fake.layerExistsReturnsOnCall[i] = struct {
+		result1 bool
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *HCSClient) NewLayerWriter(arg1 hcsshim.DriverInfo, arg2 string, arg3 []string) (hcs.LayerWriter, error) {
+	var arg3Copy []string
+	if arg3 != nil {
+		arg3Copy = make([]string, len(arg3))
+		copy(arg3Copy, arg3)
+	}
+	fake.newLayerWriterMutex.Lock()
+	ret, specificReturn := fake.newLayerWriterReturnsOnCall[len(fake.newLayerWriterArgsForCall)]
+	fake.newLayerWriterArgsForCall = append(fake.newLayerWriterArgsForCall, struct {
+		arg1 hcsshim.DriverInfo
+		arg2 string
+		arg3 []string
+	}{arg1, arg2, arg3Copy})
+	stub := fake.NewLayerWriterStub
+	fakeReturns := fake.newLayerWriterReturns
+	fake.recordInvocation("NewLayerWriter", []interface{}{arg1, arg2, arg3Copy})
+	fake.newLayerWriterMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *HCSClient) NewLayerWriterCallCount() int {
+	fake.newLayerWriterMutex.RLock()
+	defer fake.newLayerWriterMutex.RUnlock()
+	return len(fake.newLayerWriterArgsForCall)
+}
+
+func (fake *HCSClient) NewLayerWriterCalls(stub func(hcsshim.DriverInfo, string, []string) (hcs.LayerWriter, error)) {
+	fake.newLayerWriterMutex.Lock()
+	defer fake.newLayerWriterMutex.Unlock()
+	fake.NewLayerWriterStub = stub
+}
+
+func (fake *HCSClient) NewLayerWriterArgsForCall(i int) (hcsshim.DriverInfo, string, []string) {
+	fake.newLayerWriterMutex.RLock()
+	defer fake.newLayerWriterMutex.RUnlock()
+	argsForCall := fake.newLayerWriterArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *HCSClient) NewLayerWriterReturns(result1 hcs.LayerWriter, result2 error) {
+	fake.newLayerWriterMutex.Lock()
+	defer fake.newLayerWriterMutex.Unlock()
+	fake.NewLayerWriterStub = nil
+	fake.newLayerWriterReturns = struct {
+		result1 hcs.LayerWriter
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *HCSClient) NewLayerWriterReturnsOnCall(i int, result1 hcs.LayerWriter, result2 error) {
+	fake.newLayerWriterMutex.Lock()
+	defer fake.newLayerWriterMutex.Unlock()
+	fake.NewLayerWriterStub = nil
+	if fake.newLayerWriterReturnsOnCall == nil {
+		fake.newLayerWriterReturnsOnCall = make(map[int]struct {
+			result1 hcs.LayerWriter
+			result2 error
+		})
+	}
+	fake.newLayerWriterReturnsOnCall[i] = struct {
+		result1 hcs.LayerWriter
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *HCSClient) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.newLayerWriterMutex.RLock()
-	defer fake.newLayerWriterMutex.RUnlock()
 	fake.createLayerMutex.RLock()
 	defer fake.createLayerMutex.RUnlock()
-	fake.layerExistsMutex.RLock()
-	defer fake.layerExistsMutex.RUnlock()
-	fake.getLayerMountPathMutex.RLock()
-	defer fake.getLayerMountPathMutex.RUnlock()
 	fake.destroyLayerMutex.RLock()
 	defer fake.destroyLayerMutex.RUnlock()
+	fake.getLayerMountPathMutex.RLock()
+	defer fake.getLayerMountPathMutex.RUnlock()
+	fake.layerExistsMutex.RLock()
+	defer fake.layerExistsMutex.RUnlock()
+	fake.newLayerWriterMutex.RLock()
+	defer fake.newLayerWriterMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/driver/fakes/limiter.go
+++ b/driver/fakes/limiter.go
@@ -8,18 +8,6 @@ import (
 )
 
 type Limiter struct {
-	SetQuotaStub        func(string, uint64) error
-	setQuotaMutex       sync.RWMutex
-	setQuotaArgsForCall []struct {
-		arg1 string
-		arg2 uint64
-	}
-	setQuotaReturns struct {
-		result1 error
-	}
-	setQuotaReturnsOnCall map[int]struct {
-		result1 error
-	}
 	GetQuotaUsedStub        func(string) (uint64, error)
 	getQuotaUsedMutex       sync.RWMutex
 	getQuotaUsedArgsForCall []struct {
@@ -33,57 +21,20 @@ type Limiter struct {
 		result1 uint64
 		result2 error
 	}
-	invocations      map[string][][]interface{}
-	invocationsMutex sync.RWMutex
-}
-
-func (fake *Limiter) SetQuota(arg1 string, arg2 uint64) error {
-	fake.setQuotaMutex.Lock()
-	ret, specificReturn := fake.setQuotaReturnsOnCall[len(fake.setQuotaArgsForCall)]
-	fake.setQuotaArgsForCall = append(fake.setQuotaArgsForCall, struct {
+	SetQuotaStub        func(string, uint64) error
+	setQuotaMutex       sync.RWMutex
+	setQuotaArgsForCall []struct {
 		arg1 string
 		arg2 uint64
-	}{arg1, arg2})
-	fake.recordInvocation("SetQuota", []interface{}{arg1, arg2})
-	fake.setQuotaMutex.Unlock()
-	if fake.SetQuotaStub != nil {
-		return fake.SetQuotaStub(arg1, arg2)
 	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fake.setQuotaReturns.result1
-}
-
-func (fake *Limiter) SetQuotaCallCount() int {
-	fake.setQuotaMutex.RLock()
-	defer fake.setQuotaMutex.RUnlock()
-	return len(fake.setQuotaArgsForCall)
-}
-
-func (fake *Limiter) SetQuotaArgsForCall(i int) (string, uint64) {
-	fake.setQuotaMutex.RLock()
-	defer fake.setQuotaMutex.RUnlock()
-	return fake.setQuotaArgsForCall[i].arg1, fake.setQuotaArgsForCall[i].arg2
-}
-
-func (fake *Limiter) SetQuotaReturns(result1 error) {
-	fake.SetQuotaStub = nil
-	fake.setQuotaReturns = struct {
+	setQuotaReturns struct {
 		result1 error
-	}{result1}
-}
-
-func (fake *Limiter) SetQuotaReturnsOnCall(i int, result1 error) {
-	fake.SetQuotaStub = nil
-	if fake.setQuotaReturnsOnCall == nil {
-		fake.setQuotaReturnsOnCall = make(map[int]struct {
-			result1 error
-		})
 	}
-	fake.setQuotaReturnsOnCall[i] = struct {
+	setQuotaReturnsOnCall map[int]struct {
 		result1 error
-	}{result1}
+	}
+	invocations      map[string][][]interface{}
+	invocationsMutex sync.RWMutex
 }
 
 func (fake *Limiter) GetQuotaUsed(arg1 string) (uint64, error) {
@@ -92,15 +43,17 @@ func (fake *Limiter) GetQuotaUsed(arg1 string) (uint64, error) {
 	fake.getQuotaUsedArgsForCall = append(fake.getQuotaUsedArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.GetQuotaUsedStub
+	fakeReturns := fake.getQuotaUsedReturns
 	fake.recordInvocation("GetQuotaUsed", []interface{}{arg1})
 	fake.getQuotaUsedMutex.Unlock()
-	if fake.GetQuotaUsedStub != nil {
-		return fake.GetQuotaUsedStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.getQuotaUsedReturns.result1, fake.getQuotaUsedReturns.result2
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *Limiter) GetQuotaUsedCallCount() int {
@@ -109,13 +62,22 @@ func (fake *Limiter) GetQuotaUsedCallCount() int {
 	return len(fake.getQuotaUsedArgsForCall)
 }
 
+func (fake *Limiter) GetQuotaUsedCalls(stub func(string) (uint64, error)) {
+	fake.getQuotaUsedMutex.Lock()
+	defer fake.getQuotaUsedMutex.Unlock()
+	fake.GetQuotaUsedStub = stub
+}
+
 func (fake *Limiter) GetQuotaUsedArgsForCall(i int) string {
 	fake.getQuotaUsedMutex.RLock()
 	defer fake.getQuotaUsedMutex.RUnlock()
-	return fake.getQuotaUsedArgsForCall[i].arg1
+	argsForCall := fake.getQuotaUsedArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *Limiter) GetQuotaUsedReturns(result1 uint64, result2 error) {
+	fake.getQuotaUsedMutex.Lock()
+	defer fake.getQuotaUsedMutex.Unlock()
 	fake.GetQuotaUsedStub = nil
 	fake.getQuotaUsedReturns = struct {
 		result1 uint64
@@ -124,6 +86,8 @@ func (fake *Limiter) GetQuotaUsedReturns(result1 uint64, result2 error) {
 }
 
 func (fake *Limiter) GetQuotaUsedReturnsOnCall(i int, result1 uint64, result2 error) {
+	fake.getQuotaUsedMutex.Lock()
+	defer fake.getQuotaUsedMutex.Unlock()
 	fake.GetQuotaUsedStub = nil
 	if fake.getQuotaUsedReturnsOnCall == nil {
 		fake.getQuotaUsedReturnsOnCall = make(map[int]struct {
@@ -137,13 +101,75 @@ func (fake *Limiter) GetQuotaUsedReturnsOnCall(i int, result1 uint64, result2 er
 	}{result1, result2}
 }
 
+func (fake *Limiter) SetQuota(arg1 string, arg2 uint64) error {
+	fake.setQuotaMutex.Lock()
+	ret, specificReturn := fake.setQuotaReturnsOnCall[len(fake.setQuotaArgsForCall)]
+	fake.setQuotaArgsForCall = append(fake.setQuotaArgsForCall, struct {
+		arg1 string
+		arg2 uint64
+	}{arg1, arg2})
+	stub := fake.SetQuotaStub
+	fakeReturns := fake.setQuotaReturns
+	fake.recordInvocation("SetQuota", []interface{}{arg1, arg2})
+	fake.setQuotaMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *Limiter) SetQuotaCallCount() int {
+	fake.setQuotaMutex.RLock()
+	defer fake.setQuotaMutex.RUnlock()
+	return len(fake.setQuotaArgsForCall)
+}
+
+func (fake *Limiter) SetQuotaCalls(stub func(string, uint64) error) {
+	fake.setQuotaMutex.Lock()
+	defer fake.setQuotaMutex.Unlock()
+	fake.SetQuotaStub = stub
+}
+
+func (fake *Limiter) SetQuotaArgsForCall(i int) (string, uint64) {
+	fake.setQuotaMutex.RLock()
+	defer fake.setQuotaMutex.RUnlock()
+	argsForCall := fake.setQuotaArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *Limiter) SetQuotaReturns(result1 error) {
+	fake.setQuotaMutex.Lock()
+	defer fake.setQuotaMutex.Unlock()
+	fake.SetQuotaStub = nil
+	fake.setQuotaReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *Limiter) SetQuotaReturnsOnCall(i int, result1 error) {
+	fake.setQuotaMutex.Lock()
+	defer fake.setQuotaMutex.Unlock()
+	fake.SetQuotaStub = nil
+	if fake.setQuotaReturnsOnCall == nil {
+		fake.setQuotaReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.setQuotaReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *Limiter) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.setQuotaMutex.RLock()
-	defer fake.setQuotaMutex.RUnlock()
 	fake.getQuotaUsedMutex.RLock()
 	defer fake.getQuotaUsedMutex.RUnlock()
+	fake.setQuotaMutex.RLock()
+	defer fake.setQuotaMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/driver/fakes/privilege_elevator.go
+++ b/driver/fakes/privilege_elevator.go
@@ -8,17 +8,6 @@ import (
 )
 
 type PrivilegeElevator struct {
-	EnableProcessPrivilegesStub        func([]string) error
-	enableProcessPrivilegesMutex       sync.RWMutex
-	enableProcessPrivilegesArgsForCall []struct {
-		arg1 []string
-	}
-	enableProcessPrivilegesReturns struct {
-		result1 error
-	}
-	enableProcessPrivilegesReturnsOnCall map[int]struct {
-		result1 error
-	}
 	DisableProcessPrivilegesStub        func([]string) error
 	disableProcessPrivilegesMutex       sync.RWMutex
 	disableProcessPrivilegesArgsForCall []struct {
@@ -30,61 +19,19 @@ type PrivilegeElevator struct {
 	disableProcessPrivilegesReturnsOnCall map[int]struct {
 		result1 error
 	}
+	EnableProcessPrivilegesStub        func([]string) error
+	enableProcessPrivilegesMutex       sync.RWMutex
+	enableProcessPrivilegesArgsForCall []struct {
+		arg1 []string
+	}
+	enableProcessPrivilegesReturns struct {
+		result1 error
+	}
+	enableProcessPrivilegesReturnsOnCall map[int]struct {
+		result1 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
-}
-
-func (fake *PrivilegeElevator) EnableProcessPrivileges(arg1 []string) error {
-	var arg1Copy []string
-	if arg1 != nil {
-		arg1Copy = make([]string, len(arg1))
-		copy(arg1Copy, arg1)
-	}
-	fake.enableProcessPrivilegesMutex.Lock()
-	ret, specificReturn := fake.enableProcessPrivilegesReturnsOnCall[len(fake.enableProcessPrivilegesArgsForCall)]
-	fake.enableProcessPrivilegesArgsForCall = append(fake.enableProcessPrivilegesArgsForCall, struct {
-		arg1 []string
-	}{arg1Copy})
-	fake.recordInvocation("EnableProcessPrivileges", []interface{}{arg1Copy})
-	fake.enableProcessPrivilegesMutex.Unlock()
-	if fake.EnableProcessPrivilegesStub != nil {
-		return fake.EnableProcessPrivilegesStub(arg1)
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fake.enableProcessPrivilegesReturns.result1
-}
-
-func (fake *PrivilegeElevator) EnableProcessPrivilegesCallCount() int {
-	fake.enableProcessPrivilegesMutex.RLock()
-	defer fake.enableProcessPrivilegesMutex.RUnlock()
-	return len(fake.enableProcessPrivilegesArgsForCall)
-}
-
-func (fake *PrivilegeElevator) EnableProcessPrivilegesArgsForCall(i int) []string {
-	fake.enableProcessPrivilegesMutex.RLock()
-	defer fake.enableProcessPrivilegesMutex.RUnlock()
-	return fake.enableProcessPrivilegesArgsForCall[i].arg1
-}
-
-func (fake *PrivilegeElevator) EnableProcessPrivilegesReturns(result1 error) {
-	fake.EnableProcessPrivilegesStub = nil
-	fake.enableProcessPrivilegesReturns = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *PrivilegeElevator) EnableProcessPrivilegesReturnsOnCall(i int, result1 error) {
-	fake.EnableProcessPrivilegesStub = nil
-	if fake.enableProcessPrivilegesReturnsOnCall == nil {
-		fake.enableProcessPrivilegesReturnsOnCall = make(map[int]struct {
-			result1 error
-		})
-	}
-	fake.enableProcessPrivilegesReturnsOnCall[i] = struct {
-		result1 error
-	}{result1}
 }
 
 func (fake *PrivilegeElevator) DisableProcessPrivileges(arg1 []string) error {
@@ -98,15 +45,17 @@ func (fake *PrivilegeElevator) DisableProcessPrivileges(arg1 []string) error {
 	fake.disableProcessPrivilegesArgsForCall = append(fake.disableProcessPrivilegesArgsForCall, struct {
 		arg1 []string
 	}{arg1Copy})
+	stub := fake.DisableProcessPrivilegesStub
+	fakeReturns := fake.disableProcessPrivilegesReturns
 	fake.recordInvocation("DisableProcessPrivileges", []interface{}{arg1Copy})
 	fake.disableProcessPrivilegesMutex.Unlock()
-	if fake.DisableProcessPrivilegesStub != nil {
-		return fake.DisableProcessPrivilegesStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	return fake.disableProcessPrivilegesReturns.result1
+	return fakeReturns.result1
 }
 
 func (fake *PrivilegeElevator) DisableProcessPrivilegesCallCount() int {
@@ -115,13 +64,22 @@ func (fake *PrivilegeElevator) DisableProcessPrivilegesCallCount() int {
 	return len(fake.disableProcessPrivilegesArgsForCall)
 }
 
+func (fake *PrivilegeElevator) DisableProcessPrivilegesCalls(stub func([]string) error) {
+	fake.disableProcessPrivilegesMutex.Lock()
+	defer fake.disableProcessPrivilegesMutex.Unlock()
+	fake.DisableProcessPrivilegesStub = stub
+}
+
 func (fake *PrivilegeElevator) DisableProcessPrivilegesArgsForCall(i int) []string {
 	fake.disableProcessPrivilegesMutex.RLock()
 	defer fake.disableProcessPrivilegesMutex.RUnlock()
-	return fake.disableProcessPrivilegesArgsForCall[i].arg1
+	argsForCall := fake.disableProcessPrivilegesArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *PrivilegeElevator) DisableProcessPrivilegesReturns(result1 error) {
+	fake.disableProcessPrivilegesMutex.Lock()
+	defer fake.disableProcessPrivilegesMutex.Unlock()
 	fake.DisableProcessPrivilegesStub = nil
 	fake.disableProcessPrivilegesReturns = struct {
 		result1 error
@@ -129,6 +87,8 @@ func (fake *PrivilegeElevator) DisableProcessPrivilegesReturns(result1 error) {
 }
 
 func (fake *PrivilegeElevator) DisableProcessPrivilegesReturnsOnCall(i int, result1 error) {
+	fake.disableProcessPrivilegesMutex.Lock()
+	defer fake.disableProcessPrivilegesMutex.Unlock()
 	fake.DisableProcessPrivilegesStub = nil
 	if fake.disableProcessPrivilegesReturnsOnCall == nil {
 		fake.disableProcessPrivilegesReturnsOnCall = make(map[int]struct {
@@ -140,13 +100,79 @@ func (fake *PrivilegeElevator) DisableProcessPrivilegesReturnsOnCall(i int, resu
 	}{result1}
 }
 
+func (fake *PrivilegeElevator) EnableProcessPrivileges(arg1 []string) error {
+	var arg1Copy []string
+	if arg1 != nil {
+		arg1Copy = make([]string, len(arg1))
+		copy(arg1Copy, arg1)
+	}
+	fake.enableProcessPrivilegesMutex.Lock()
+	ret, specificReturn := fake.enableProcessPrivilegesReturnsOnCall[len(fake.enableProcessPrivilegesArgsForCall)]
+	fake.enableProcessPrivilegesArgsForCall = append(fake.enableProcessPrivilegesArgsForCall, struct {
+		arg1 []string
+	}{arg1Copy})
+	stub := fake.EnableProcessPrivilegesStub
+	fakeReturns := fake.enableProcessPrivilegesReturns
+	fake.recordInvocation("EnableProcessPrivileges", []interface{}{arg1Copy})
+	fake.enableProcessPrivilegesMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *PrivilegeElevator) EnableProcessPrivilegesCallCount() int {
+	fake.enableProcessPrivilegesMutex.RLock()
+	defer fake.enableProcessPrivilegesMutex.RUnlock()
+	return len(fake.enableProcessPrivilegesArgsForCall)
+}
+
+func (fake *PrivilegeElevator) EnableProcessPrivilegesCalls(stub func([]string) error) {
+	fake.enableProcessPrivilegesMutex.Lock()
+	defer fake.enableProcessPrivilegesMutex.Unlock()
+	fake.EnableProcessPrivilegesStub = stub
+}
+
+func (fake *PrivilegeElevator) EnableProcessPrivilegesArgsForCall(i int) []string {
+	fake.enableProcessPrivilegesMutex.RLock()
+	defer fake.enableProcessPrivilegesMutex.RUnlock()
+	argsForCall := fake.enableProcessPrivilegesArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *PrivilegeElevator) EnableProcessPrivilegesReturns(result1 error) {
+	fake.enableProcessPrivilegesMutex.Lock()
+	defer fake.enableProcessPrivilegesMutex.Unlock()
+	fake.EnableProcessPrivilegesStub = nil
+	fake.enableProcessPrivilegesReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *PrivilegeElevator) EnableProcessPrivilegesReturnsOnCall(i int, result1 error) {
+	fake.enableProcessPrivilegesMutex.Lock()
+	defer fake.enableProcessPrivilegesMutex.Unlock()
+	fake.EnableProcessPrivilegesStub = nil
+	if fake.enableProcessPrivilegesReturnsOnCall == nil {
+		fake.enableProcessPrivilegesReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.enableProcessPrivilegesReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *PrivilegeElevator) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.enableProcessPrivilegesMutex.RLock()
-	defer fake.enableProcessPrivilegesMutex.RUnlock()
 	fake.disableProcessPrivilegesMutex.RLock()
 	defer fake.disableProcessPrivilegesMutex.RUnlock()
+	fake.enableProcessPrivilegesMutex.RLock()
+	defer fake.enableProcessPrivilegesMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/driver/fakes/tarstreamer.go
+++ b/driver/fakes/tarstreamer.go
@@ -2,32 +2,15 @@
 package fakes
 
 import (
+	"archive/tar"
 	"io"
 	"sync"
 
-	"archive/tar"
-
 	"code.cloudfoundry.org/groot-windows/driver"
-	"github.com/Microsoft/go-winio"
+	winio "github.com/Microsoft/go-winio"
 )
 
 type TarStreamer struct {
-	SetReaderStub        func(io.Reader)
-	setReaderMutex       sync.RWMutex
-	setReaderArgsForCall []struct {
-		arg1 io.Reader
-	}
-	NextStub        func() (*tar.Header, error)
-	nextMutex       sync.RWMutex
-	nextArgsForCall []struct{}
-	nextReturns     struct {
-		result1 *tar.Header
-		result2 error
-	}
-	nextReturnsOnCall map[int]struct {
-		result1 *tar.Header
-		result2 error
-	}
 	FileInfoFromHeaderStub        func(*tar.Header) (string, int64, *winio.FileBasicInfo, error)
 	fileInfoFromHeaderMutex       sync.RWMutex
 	fileInfoFromHeaderArgsForCall []struct {
@@ -45,11 +28,29 @@ type TarStreamer struct {
 		result3 *winio.FileBasicInfo
 		result4 error
 	}
-	WriteBackupStreamFromTarFileStub        func(io.Writer, *tar.Header) (*tar.Header, error)
+	NextStub        func() (*tar.Header, error)
+	nextMutex       sync.RWMutex
+	nextArgsForCall []struct {
+	}
+	nextReturns struct {
+		result1 *tar.Header
+		result2 error
+	}
+	nextReturnsOnCall map[int]struct {
+		result1 *tar.Header
+		result2 error
+	}
+	SetReaderStub        func(io.Reader)
+	setReaderMutex       sync.RWMutex
+	setReaderArgsForCall []struct {
+		arg1 io.Reader
+	}
+	WriteBackupStreamFromTarFileStub        func(io.Writer, *tar.Header, string) (*tar.Header, error)
 	writeBackupStreamFromTarFileMutex       sync.RWMutex
 	writeBackupStreamFromTarFileArgsForCall []struct {
 		arg1 io.Writer
 		arg2 *tar.Header
+		arg3 string
 	}
 	writeBackupStreamFromTarFileReturns struct {
 		result1 *tar.Header
@@ -63,88 +64,23 @@ type TarStreamer struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *TarStreamer) SetReader(arg1 io.Reader) {
-	fake.setReaderMutex.Lock()
-	fake.setReaderArgsForCall = append(fake.setReaderArgsForCall, struct {
-		arg1 io.Reader
-	}{arg1})
-	fake.recordInvocation("SetReader", []interface{}{arg1})
-	fake.setReaderMutex.Unlock()
-	if fake.SetReaderStub != nil {
-		fake.SetReaderStub(arg1)
-	}
-}
-
-func (fake *TarStreamer) SetReaderCallCount() int {
-	fake.setReaderMutex.RLock()
-	defer fake.setReaderMutex.RUnlock()
-	return len(fake.setReaderArgsForCall)
-}
-
-func (fake *TarStreamer) SetReaderArgsForCall(i int) io.Reader {
-	fake.setReaderMutex.RLock()
-	defer fake.setReaderMutex.RUnlock()
-	return fake.setReaderArgsForCall[i].arg1
-}
-
-func (fake *TarStreamer) Next() (*tar.Header, error) {
-	fake.nextMutex.Lock()
-	ret, specificReturn := fake.nextReturnsOnCall[len(fake.nextArgsForCall)]
-	fake.nextArgsForCall = append(fake.nextArgsForCall, struct{}{})
-	fake.recordInvocation("Next", []interface{}{})
-	fake.nextMutex.Unlock()
-	if fake.NextStub != nil {
-		return fake.NextStub()
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	return fake.nextReturns.result1, fake.nextReturns.result2
-}
-
-func (fake *TarStreamer) NextCallCount() int {
-	fake.nextMutex.RLock()
-	defer fake.nextMutex.RUnlock()
-	return len(fake.nextArgsForCall)
-}
-
-func (fake *TarStreamer) NextReturns(result1 *tar.Header, result2 error) {
-	fake.NextStub = nil
-	fake.nextReturns = struct {
-		result1 *tar.Header
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *TarStreamer) NextReturnsOnCall(i int, result1 *tar.Header, result2 error) {
-	fake.NextStub = nil
-	if fake.nextReturnsOnCall == nil {
-		fake.nextReturnsOnCall = make(map[int]struct {
-			result1 *tar.Header
-			result2 error
-		})
-	}
-	fake.nextReturnsOnCall[i] = struct {
-		result1 *tar.Header
-		result2 error
-	}{result1, result2}
-}
-
 func (fake *TarStreamer) FileInfoFromHeader(arg1 *tar.Header) (string, int64, *winio.FileBasicInfo, error) {
 	fake.fileInfoFromHeaderMutex.Lock()
 	ret, specificReturn := fake.fileInfoFromHeaderReturnsOnCall[len(fake.fileInfoFromHeaderArgsForCall)]
 	fake.fileInfoFromHeaderArgsForCall = append(fake.fileInfoFromHeaderArgsForCall, struct {
 		arg1 *tar.Header
 	}{arg1})
+	stub := fake.FileInfoFromHeaderStub
+	fakeReturns := fake.fileInfoFromHeaderReturns
 	fake.recordInvocation("FileInfoFromHeader", []interface{}{arg1})
 	fake.fileInfoFromHeaderMutex.Unlock()
-	if fake.FileInfoFromHeaderStub != nil {
-		return fake.FileInfoFromHeaderStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3, ret.result4
 	}
-	return fake.fileInfoFromHeaderReturns.result1, fake.fileInfoFromHeaderReturns.result2, fake.fileInfoFromHeaderReturns.result3, fake.fileInfoFromHeaderReturns.result4
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3, fakeReturns.result4
 }
 
 func (fake *TarStreamer) FileInfoFromHeaderCallCount() int {
@@ -153,13 +89,22 @@ func (fake *TarStreamer) FileInfoFromHeaderCallCount() int {
 	return len(fake.fileInfoFromHeaderArgsForCall)
 }
 
+func (fake *TarStreamer) FileInfoFromHeaderCalls(stub func(*tar.Header) (string, int64, *winio.FileBasicInfo, error)) {
+	fake.fileInfoFromHeaderMutex.Lock()
+	defer fake.fileInfoFromHeaderMutex.Unlock()
+	fake.FileInfoFromHeaderStub = stub
+}
+
 func (fake *TarStreamer) FileInfoFromHeaderArgsForCall(i int) *tar.Header {
 	fake.fileInfoFromHeaderMutex.RLock()
 	defer fake.fileInfoFromHeaderMutex.RUnlock()
-	return fake.fileInfoFromHeaderArgsForCall[i].arg1
+	argsForCall := fake.fileInfoFromHeaderArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *TarStreamer) FileInfoFromHeaderReturns(result1 string, result2 int64, result3 *winio.FileBasicInfo, result4 error) {
+	fake.fileInfoFromHeaderMutex.Lock()
+	defer fake.fileInfoFromHeaderMutex.Unlock()
 	fake.FileInfoFromHeaderStub = nil
 	fake.fileInfoFromHeaderReturns = struct {
 		result1 string
@@ -170,6 +115,8 @@ func (fake *TarStreamer) FileInfoFromHeaderReturns(result1 string, result2 int64
 }
 
 func (fake *TarStreamer) FileInfoFromHeaderReturnsOnCall(i int, result1 string, result2 int64, result3 *winio.FileBasicInfo, result4 error) {
+	fake.fileInfoFromHeaderMutex.Lock()
+	defer fake.fileInfoFromHeaderMutex.Unlock()
 	fake.FileInfoFromHeaderStub = nil
 	if fake.fileInfoFromHeaderReturnsOnCall == nil {
 		fake.fileInfoFromHeaderReturnsOnCall = make(map[int]struct {
@@ -187,22 +134,113 @@ func (fake *TarStreamer) FileInfoFromHeaderReturnsOnCall(i int, result1 string, 
 	}{result1, result2, result3, result4}
 }
 
-func (fake *TarStreamer) WriteBackupStreamFromTarFile(arg1 io.Writer, arg2 *tar.Header) (*tar.Header, error) {
+func (fake *TarStreamer) Next() (*tar.Header, error) {
+	fake.nextMutex.Lock()
+	ret, specificReturn := fake.nextReturnsOnCall[len(fake.nextArgsForCall)]
+	fake.nextArgsForCall = append(fake.nextArgsForCall, struct {
+	}{})
+	stub := fake.NextStub
+	fakeReturns := fake.nextReturns
+	fake.recordInvocation("Next", []interface{}{})
+	fake.nextMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *TarStreamer) NextCallCount() int {
+	fake.nextMutex.RLock()
+	defer fake.nextMutex.RUnlock()
+	return len(fake.nextArgsForCall)
+}
+
+func (fake *TarStreamer) NextCalls(stub func() (*tar.Header, error)) {
+	fake.nextMutex.Lock()
+	defer fake.nextMutex.Unlock()
+	fake.NextStub = stub
+}
+
+func (fake *TarStreamer) NextReturns(result1 *tar.Header, result2 error) {
+	fake.nextMutex.Lock()
+	defer fake.nextMutex.Unlock()
+	fake.NextStub = nil
+	fake.nextReturns = struct {
+		result1 *tar.Header
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *TarStreamer) NextReturnsOnCall(i int, result1 *tar.Header, result2 error) {
+	fake.nextMutex.Lock()
+	defer fake.nextMutex.Unlock()
+	fake.NextStub = nil
+	if fake.nextReturnsOnCall == nil {
+		fake.nextReturnsOnCall = make(map[int]struct {
+			result1 *tar.Header
+			result2 error
+		})
+	}
+	fake.nextReturnsOnCall[i] = struct {
+		result1 *tar.Header
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *TarStreamer) SetReader(arg1 io.Reader) {
+	fake.setReaderMutex.Lock()
+	fake.setReaderArgsForCall = append(fake.setReaderArgsForCall, struct {
+		arg1 io.Reader
+	}{arg1})
+	stub := fake.SetReaderStub
+	fake.recordInvocation("SetReader", []interface{}{arg1})
+	fake.setReaderMutex.Unlock()
+	if stub != nil {
+		fake.SetReaderStub(arg1)
+	}
+}
+
+func (fake *TarStreamer) SetReaderCallCount() int {
+	fake.setReaderMutex.RLock()
+	defer fake.setReaderMutex.RUnlock()
+	return len(fake.setReaderArgsForCall)
+}
+
+func (fake *TarStreamer) SetReaderCalls(stub func(io.Reader)) {
+	fake.setReaderMutex.Lock()
+	defer fake.setReaderMutex.Unlock()
+	fake.SetReaderStub = stub
+}
+
+func (fake *TarStreamer) SetReaderArgsForCall(i int) io.Reader {
+	fake.setReaderMutex.RLock()
+	defer fake.setReaderMutex.RUnlock()
+	argsForCall := fake.setReaderArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *TarStreamer) WriteBackupStreamFromTarFile(arg1 io.Writer, arg2 *tar.Header, arg3 string) (*tar.Header, error) {
 	fake.writeBackupStreamFromTarFileMutex.Lock()
 	ret, specificReturn := fake.writeBackupStreamFromTarFileReturnsOnCall[len(fake.writeBackupStreamFromTarFileArgsForCall)]
 	fake.writeBackupStreamFromTarFileArgsForCall = append(fake.writeBackupStreamFromTarFileArgsForCall, struct {
 		arg1 io.Writer
 		arg2 *tar.Header
-	}{arg1, arg2})
-	fake.recordInvocation("WriteBackupStreamFromTarFile", []interface{}{arg1, arg2})
+		arg3 string
+	}{arg1, arg2, arg3})
+	stub := fake.WriteBackupStreamFromTarFileStub
+	fakeReturns := fake.writeBackupStreamFromTarFileReturns
+	fake.recordInvocation("WriteBackupStreamFromTarFile", []interface{}{arg1, arg2, arg3})
 	fake.writeBackupStreamFromTarFileMutex.Unlock()
-	if fake.WriteBackupStreamFromTarFileStub != nil {
-		return fake.WriteBackupStreamFromTarFileStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.writeBackupStreamFromTarFileReturns.result1, fake.writeBackupStreamFromTarFileReturns.result2
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *TarStreamer) WriteBackupStreamFromTarFileCallCount() int {
@@ -211,13 +249,22 @@ func (fake *TarStreamer) WriteBackupStreamFromTarFileCallCount() int {
 	return len(fake.writeBackupStreamFromTarFileArgsForCall)
 }
 
-func (fake *TarStreamer) WriteBackupStreamFromTarFileArgsForCall(i int) (io.Writer, *tar.Header) {
+func (fake *TarStreamer) WriteBackupStreamFromTarFileCalls(stub func(io.Writer, *tar.Header, string) (*tar.Header, error)) {
+	fake.writeBackupStreamFromTarFileMutex.Lock()
+	defer fake.writeBackupStreamFromTarFileMutex.Unlock()
+	fake.WriteBackupStreamFromTarFileStub = stub
+}
+
+func (fake *TarStreamer) WriteBackupStreamFromTarFileArgsForCall(i int) (io.Writer, *tar.Header, string) {
 	fake.writeBackupStreamFromTarFileMutex.RLock()
 	defer fake.writeBackupStreamFromTarFileMutex.RUnlock()
-	return fake.writeBackupStreamFromTarFileArgsForCall[i].arg1, fake.writeBackupStreamFromTarFileArgsForCall[i].arg2
+	argsForCall := fake.writeBackupStreamFromTarFileArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *TarStreamer) WriteBackupStreamFromTarFileReturns(result1 *tar.Header, result2 error) {
+	fake.writeBackupStreamFromTarFileMutex.Lock()
+	defer fake.writeBackupStreamFromTarFileMutex.Unlock()
 	fake.WriteBackupStreamFromTarFileStub = nil
 	fake.writeBackupStreamFromTarFileReturns = struct {
 		result1 *tar.Header
@@ -226,6 +273,8 @@ func (fake *TarStreamer) WriteBackupStreamFromTarFileReturns(result1 *tar.Header
 }
 
 func (fake *TarStreamer) WriteBackupStreamFromTarFileReturnsOnCall(i int, result1 *tar.Header, result2 error) {
+	fake.writeBackupStreamFromTarFileMutex.Lock()
+	defer fake.writeBackupStreamFromTarFileMutex.Unlock()
 	fake.WriteBackupStreamFromTarFileStub = nil
 	if fake.writeBackupStreamFromTarFileReturnsOnCall == nil {
 		fake.writeBackupStreamFromTarFileReturnsOnCall = make(map[int]struct {
@@ -242,12 +291,12 @@ func (fake *TarStreamer) WriteBackupStreamFromTarFileReturnsOnCall(i int, result
 func (fake *TarStreamer) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.setReaderMutex.RLock()
-	defer fake.setReaderMutex.RUnlock()
-	fake.nextMutex.RLock()
-	defer fake.nextMutex.RUnlock()
 	fake.fileInfoFromHeaderMutex.RLock()
 	defer fake.fileInfoFromHeaderMutex.RUnlock()
+	fake.nextMutex.RLock()
+	defer fake.nextMutex.RUnlock()
+	fake.setReaderMutex.RLock()
+	defer fake.setReaderMutex.RUnlock()
 	fake.writeBackupStreamFromTarFileMutex.RLock()
 	defer fake.writeBackupStreamFromTarFileMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/driver/unpack.go
+++ b/driver/unpack.go
@@ -108,7 +108,7 @@ func (d *Driver) Unpack(logger lager.Logger, layerID string, parentIDs []string,
 				return 0, err
 			}
 
-			hdr, nextFileErr = d.tarStreamer.WriteBackupStreamFromTarFile(layerWriter, hdr)
+			hdr, nextFileErr = d.tarStreamer.WriteBackupStreamFromTarFile(layerWriter, hdr, filepath.Join(d.LayerStore(), layerID))
 			totalSize += size
 		}
 

--- a/driver/unpack_test.go
+++ b/driver/unpack_test.go
@@ -275,12 +275,14 @@ var _ = Describe("Unpack", func() {
 			var (
 				tarHeader *tar.Header
 				fileInfo  *winio.FileBasicInfo
+				layerPath string
 			)
 
 			BeforeEach(func() {
 				tarHeader = &tar.Header{
 					Name: "regular/file/name",
 				}
+				layerPath = filepath.Join(d.LayerStore(), layerID)
 				tarStreamerFake.NextReturnsOnCall(0, tarHeader, nil)
 				fileInfo = &winio.FileBasicInfo{}
 				tarStreamerFake.FileInfoFromHeaderReturns("regular/file/name", 100, fileInfo, nil)
@@ -301,9 +303,10 @@ var _ = Describe("Unpack", func() {
 				Expect(actualFileInfo).To(Equal(fileInfo))
 
 				Expect(tarStreamerFake.WriteBackupStreamFromTarFileCallCount()).To(Equal(1))
-				actualWriter, actualTarHeader := tarStreamerFake.WriteBackupStreamFromTarFileArgsForCall(0)
+				actualWriter, actualTarHeader, actualLayerPath := tarStreamerFake.WriteBackupStreamFromTarFileArgsForCall(0)
 				Expect(actualWriter).To(Equal(layerWriterFake))
 				Expect(actualTarHeader).To(Equal(tarHeader))
+				Expect(actualLayerPath).To(Equal(layerPath))
 			})
 
 			It("returns the size of the layer", func() {

--- a/hcs/fakes/layer_writer.go
+++ b/hcs/fakes/layer_writer.go
@@ -5,15 +5,15 @@ import (
 	"sync"
 
 	"code.cloudfoundry.org/groot-windows/hcs"
-	"github.com/Microsoft/go-winio"
+	winio "github.com/Microsoft/go-winio"
 )
 
 type LayerWriter struct {
-	AddStub        func(name string, fileInfo *winio.FileBasicInfo) error
+	AddStub        func(string, *winio.FileBasicInfo) error
 	addMutex       sync.RWMutex
 	addArgsForCall []struct {
-		name     string
-		fileInfo *winio.FileBasicInfo
+		arg1 string
+		arg2 *winio.FileBasicInfo
 	}
 	addReturns struct {
 		result1 error
@@ -21,11 +21,11 @@ type LayerWriter struct {
 	addReturnsOnCall map[int]struct {
 		result1 error
 	}
-	AddLinkStub        func(name string, target string) error
+	AddLinkStub        func(string, string) error
 	addLinkMutex       sync.RWMutex
 	addLinkArgsForCall []struct {
-		name   string
-		target string
+		arg1 string
+		arg2 string
 	}
 	addLinkReturns struct {
 		result1 error
@@ -33,10 +33,20 @@ type LayerWriter struct {
 	addLinkReturnsOnCall map[int]struct {
 		result1 error
 	}
-	RemoveStub        func(name string) error
+	CloseStub        func() error
+	closeMutex       sync.RWMutex
+	closeArgsForCall []struct {
+	}
+	closeReturns struct {
+		result1 error
+	}
+	closeReturnsOnCall map[int]struct {
+		result1 error
+	}
+	RemoveStub        func(string) error
 	removeMutex       sync.RWMutex
 	removeArgsForCall []struct {
-		name string
+		arg1 string
 	}
 	removeReturns struct {
 		result1 error
@@ -44,10 +54,10 @@ type LayerWriter struct {
 	removeReturnsOnCall map[int]struct {
 		result1 error
 	}
-	WriteStub        func(b []byte) (int, error)
+	WriteStub        func([]byte) (int, error)
 	writeMutex       sync.RWMutex
 	writeArgsForCall []struct {
-		b []byte
+		arg1 []byte
 	}
 	writeReturns struct {
 		result1 int
@@ -57,35 +67,28 @@ type LayerWriter struct {
 		result1 int
 		result2 error
 	}
-	CloseStub        func() error
-	closeMutex       sync.RWMutex
-	closeArgsForCall []struct{}
-	closeReturns     struct {
-		result1 error
-	}
-	closeReturnsOnCall map[int]struct {
-		result1 error
-	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *LayerWriter) Add(name string, fileInfo *winio.FileBasicInfo) error {
+func (fake *LayerWriter) Add(arg1 string, arg2 *winio.FileBasicInfo) error {
 	fake.addMutex.Lock()
 	ret, specificReturn := fake.addReturnsOnCall[len(fake.addArgsForCall)]
 	fake.addArgsForCall = append(fake.addArgsForCall, struct {
-		name     string
-		fileInfo *winio.FileBasicInfo
-	}{name, fileInfo})
-	fake.recordInvocation("Add", []interface{}{name, fileInfo})
+		arg1 string
+		arg2 *winio.FileBasicInfo
+	}{arg1, arg2})
+	stub := fake.AddStub
+	fakeReturns := fake.addReturns
+	fake.recordInvocation("Add", []interface{}{arg1, arg2})
 	fake.addMutex.Unlock()
-	if fake.AddStub != nil {
-		return fake.AddStub(name, fileInfo)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	return fake.addReturns.result1
+	return fakeReturns.result1
 }
 
 func (fake *LayerWriter) AddCallCount() int {
@@ -94,13 +97,22 @@ func (fake *LayerWriter) AddCallCount() int {
 	return len(fake.addArgsForCall)
 }
 
+func (fake *LayerWriter) AddCalls(stub func(string, *winio.FileBasicInfo) error) {
+	fake.addMutex.Lock()
+	defer fake.addMutex.Unlock()
+	fake.AddStub = stub
+}
+
 func (fake *LayerWriter) AddArgsForCall(i int) (string, *winio.FileBasicInfo) {
 	fake.addMutex.RLock()
 	defer fake.addMutex.RUnlock()
-	return fake.addArgsForCall[i].name, fake.addArgsForCall[i].fileInfo
+	argsForCall := fake.addArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *LayerWriter) AddReturns(result1 error) {
+	fake.addMutex.Lock()
+	defer fake.addMutex.Unlock()
 	fake.AddStub = nil
 	fake.addReturns = struct {
 		result1 error
@@ -108,6 +120,8 @@ func (fake *LayerWriter) AddReturns(result1 error) {
 }
 
 func (fake *LayerWriter) AddReturnsOnCall(i int, result1 error) {
+	fake.addMutex.Lock()
+	defer fake.addMutex.Unlock()
 	fake.AddStub = nil
 	if fake.addReturnsOnCall == nil {
 		fake.addReturnsOnCall = make(map[int]struct {
@@ -119,22 +133,24 @@ func (fake *LayerWriter) AddReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *LayerWriter) AddLink(name string, target string) error {
+func (fake *LayerWriter) AddLink(arg1 string, arg2 string) error {
 	fake.addLinkMutex.Lock()
 	ret, specificReturn := fake.addLinkReturnsOnCall[len(fake.addLinkArgsForCall)]
 	fake.addLinkArgsForCall = append(fake.addLinkArgsForCall, struct {
-		name   string
-		target string
-	}{name, target})
-	fake.recordInvocation("AddLink", []interface{}{name, target})
+		arg1 string
+		arg2 string
+	}{arg1, arg2})
+	stub := fake.AddLinkStub
+	fakeReturns := fake.addLinkReturns
+	fake.recordInvocation("AddLink", []interface{}{arg1, arg2})
 	fake.addLinkMutex.Unlock()
-	if fake.AddLinkStub != nil {
-		return fake.AddLinkStub(name, target)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	return fake.addLinkReturns.result1
+	return fakeReturns.result1
 }
 
 func (fake *LayerWriter) AddLinkCallCount() int {
@@ -143,13 +159,22 @@ func (fake *LayerWriter) AddLinkCallCount() int {
 	return len(fake.addLinkArgsForCall)
 }
 
+func (fake *LayerWriter) AddLinkCalls(stub func(string, string) error) {
+	fake.addLinkMutex.Lock()
+	defer fake.addLinkMutex.Unlock()
+	fake.AddLinkStub = stub
+}
+
 func (fake *LayerWriter) AddLinkArgsForCall(i int) (string, string) {
 	fake.addLinkMutex.RLock()
 	defer fake.addLinkMutex.RUnlock()
-	return fake.addLinkArgsForCall[i].name, fake.addLinkArgsForCall[i].target
+	argsForCall := fake.addLinkArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *LayerWriter) AddLinkReturns(result1 error) {
+	fake.addLinkMutex.Lock()
+	defer fake.addLinkMutex.Unlock()
 	fake.AddLinkStub = nil
 	fake.addLinkReturns = struct {
 		result1 error
@@ -157,6 +182,8 @@ func (fake *LayerWriter) AddLinkReturns(result1 error) {
 }
 
 func (fake *LayerWriter) AddLinkReturnsOnCall(i int, result1 error) {
+	fake.addLinkMutex.Lock()
+	defer fake.addLinkMutex.Unlock()
 	fake.AddLinkStub = nil
 	if fake.addLinkReturnsOnCall == nil {
 		fake.addLinkReturnsOnCall = make(map[int]struct {
@@ -168,21 +195,76 @@ func (fake *LayerWriter) AddLinkReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *LayerWriter) Remove(name string) error {
-	fake.removeMutex.Lock()
-	ret, specificReturn := fake.removeReturnsOnCall[len(fake.removeArgsForCall)]
-	fake.removeArgsForCall = append(fake.removeArgsForCall, struct {
-		name string
-	}{name})
-	fake.recordInvocation("Remove", []interface{}{name})
-	fake.removeMutex.Unlock()
-	if fake.RemoveStub != nil {
-		return fake.RemoveStub(name)
+func (fake *LayerWriter) Close() error {
+	fake.closeMutex.Lock()
+	ret, specificReturn := fake.closeReturnsOnCall[len(fake.closeArgsForCall)]
+	fake.closeArgsForCall = append(fake.closeArgsForCall, struct {
+	}{})
+	stub := fake.CloseStub
+	fakeReturns := fake.closeReturns
+	fake.recordInvocation("Close", []interface{}{})
+	fake.closeMutex.Unlock()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	return fake.removeReturns.result1
+	return fakeReturns.result1
+}
+
+func (fake *LayerWriter) CloseCallCount() int {
+	fake.closeMutex.RLock()
+	defer fake.closeMutex.RUnlock()
+	return len(fake.closeArgsForCall)
+}
+
+func (fake *LayerWriter) CloseCalls(stub func() error) {
+	fake.closeMutex.Lock()
+	defer fake.closeMutex.Unlock()
+	fake.CloseStub = stub
+}
+
+func (fake *LayerWriter) CloseReturns(result1 error) {
+	fake.closeMutex.Lock()
+	defer fake.closeMutex.Unlock()
+	fake.CloseStub = nil
+	fake.closeReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *LayerWriter) CloseReturnsOnCall(i int, result1 error) {
+	fake.closeMutex.Lock()
+	defer fake.closeMutex.Unlock()
+	fake.CloseStub = nil
+	if fake.closeReturnsOnCall == nil {
+		fake.closeReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.closeReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *LayerWriter) Remove(arg1 string) error {
+	fake.removeMutex.Lock()
+	ret, specificReturn := fake.removeReturnsOnCall[len(fake.removeArgsForCall)]
+	fake.removeArgsForCall = append(fake.removeArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	stub := fake.RemoveStub
+	fakeReturns := fake.removeReturns
+	fake.recordInvocation("Remove", []interface{}{arg1})
+	fake.removeMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
 }
 
 func (fake *LayerWriter) RemoveCallCount() int {
@@ -191,13 +273,22 @@ func (fake *LayerWriter) RemoveCallCount() int {
 	return len(fake.removeArgsForCall)
 }
 
+func (fake *LayerWriter) RemoveCalls(stub func(string) error) {
+	fake.removeMutex.Lock()
+	defer fake.removeMutex.Unlock()
+	fake.RemoveStub = stub
+}
+
 func (fake *LayerWriter) RemoveArgsForCall(i int) string {
 	fake.removeMutex.RLock()
 	defer fake.removeMutex.RUnlock()
-	return fake.removeArgsForCall[i].name
+	argsForCall := fake.removeArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *LayerWriter) RemoveReturns(result1 error) {
+	fake.removeMutex.Lock()
+	defer fake.removeMutex.Unlock()
 	fake.RemoveStub = nil
 	fake.removeReturns = struct {
 		result1 error
@@ -205,6 +296,8 @@ func (fake *LayerWriter) RemoveReturns(result1 error) {
 }
 
 func (fake *LayerWriter) RemoveReturnsOnCall(i int, result1 error) {
+	fake.removeMutex.Lock()
+	defer fake.removeMutex.Unlock()
 	fake.RemoveStub = nil
 	if fake.removeReturnsOnCall == nil {
 		fake.removeReturnsOnCall = make(map[int]struct {
@@ -216,26 +309,28 @@ func (fake *LayerWriter) RemoveReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *LayerWriter) Write(b []byte) (int, error) {
-	var bCopy []byte
-	if b != nil {
-		bCopy = make([]byte, len(b))
-		copy(bCopy, b)
+func (fake *LayerWriter) Write(arg1 []byte) (int, error) {
+	var arg1Copy []byte
+	if arg1 != nil {
+		arg1Copy = make([]byte, len(arg1))
+		copy(arg1Copy, arg1)
 	}
 	fake.writeMutex.Lock()
 	ret, specificReturn := fake.writeReturnsOnCall[len(fake.writeArgsForCall)]
 	fake.writeArgsForCall = append(fake.writeArgsForCall, struct {
-		b []byte
-	}{bCopy})
-	fake.recordInvocation("Write", []interface{}{bCopy})
+		arg1 []byte
+	}{arg1Copy})
+	stub := fake.WriteStub
+	fakeReturns := fake.writeReturns
+	fake.recordInvocation("Write", []interface{}{arg1Copy})
 	fake.writeMutex.Unlock()
-	if fake.WriteStub != nil {
-		return fake.WriteStub(b)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.writeReturns.result1, fake.writeReturns.result2
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *LayerWriter) WriteCallCount() int {
@@ -244,13 +339,22 @@ func (fake *LayerWriter) WriteCallCount() int {
 	return len(fake.writeArgsForCall)
 }
 
+func (fake *LayerWriter) WriteCalls(stub func([]byte) (int, error)) {
+	fake.writeMutex.Lock()
+	defer fake.writeMutex.Unlock()
+	fake.WriteStub = stub
+}
+
 func (fake *LayerWriter) WriteArgsForCall(i int) []byte {
 	fake.writeMutex.RLock()
 	defer fake.writeMutex.RUnlock()
-	return fake.writeArgsForCall[i].b
+	argsForCall := fake.writeArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *LayerWriter) WriteReturns(result1 int, result2 error) {
+	fake.writeMutex.Lock()
+	defer fake.writeMutex.Unlock()
 	fake.WriteStub = nil
 	fake.writeReturns = struct {
 		result1 int
@@ -259,6 +363,8 @@ func (fake *LayerWriter) WriteReturns(result1 int, result2 error) {
 }
 
 func (fake *LayerWriter) WriteReturnsOnCall(i int, result1 int, result2 error) {
+	fake.writeMutex.Lock()
+	defer fake.writeMutex.Unlock()
 	fake.WriteStub = nil
 	if fake.writeReturnsOnCall == nil {
 		fake.writeReturnsOnCall = make(map[int]struct {
@@ -272,46 +378,6 @@ func (fake *LayerWriter) WriteReturnsOnCall(i int, result1 int, result2 error) {
 	}{result1, result2}
 }
 
-func (fake *LayerWriter) Close() error {
-	fake.closeMutex.Lock()
-	ret, specificReturn := fake.closeReturnsOnCall[len(fake.closeArgsForCall)]
-	fake.closeArgsForCall = append(fake.closeArgsForCall, struct{}{})
-	fake.recordInvocation("Close", []interface{}{})
-	fake.closeMutex.Unlock()
-	if fake.CloseStub != nil {
-		return fake.CloseStub()
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fake.closeReturns.result1
-}
-
-func (fake *LayerWriter) CloseCallCount() int {
-	fake.closeMutex.RLock()
-	defer fake.closeMutex.RUnlock()
-	return len(fake.closeArgsForCall)
-}
-
-func (fake *LayerWriter) CloseReturns(result1 error) {
-	fake.CloseStub = nil
-	fake.closeReturns = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *LayerWriter) CloseReturnsOnCall(i int, result1 error) {
-	fake.CloseStub = nil
-	if fake.closeReturnsOnCall == nil {
-		fake.closeReturnsOnCall = make(map[int]struct {
-			result1 error
-		})
-	}
-	fake.closeReturnsOnCall[i] = struct {
-		result1 error
-	}{result1}
-}
-
 func (fake *LayerWriter) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -319,12 +385,12 @@ func (fake *LayerWriter) Invocations() map[string][][]interface{} {
 	defer fake.addMutex.RUnlock()
 	fake.addLinkMutex.RLock()
 	defer fake.addLinkMutex.RUnlock()
+	fake.closeMutex.RLock()
+	defer fake.closeMutex.RUnlock()
 	fake.removeMutex.RLock()
 	defer fake.removeMutex.RUnlock()
 	fake.writeMutex.RLock()
 	defer fake.writeMutex.RUnlock()
-	fake.closeMutex.RLock()
-	defer fake.closeMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/integration/pull_test.go
+++ b/integration/pull_test.go
@@ -1,6 +1,7 @@
 package integration_test
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -96,6 +97,24 @@ var _ = Describe("Pull", func() {
 			for _, chainID := range chainIDs {
 				Expect(filepath.Join(layerStore, chainID, "Files")).To(BeADirectory())
 			}
+
+			foundMutatedFiles := map[string]bool{
+				"bcd.bak":      false,
+				"bcd.log.bak":  false,
+				"bcd.log1.bak": false,
+				"bcd.log2.bak": false,
+			}
+			for _, chainId := range chainIDs {
+				for key := range foundMutatedFiles {
+					if _, err := os.Stat(filepath.Join(layerStore, chainId, key)); err == nil {
+						foundMutatedFiles[key] = true
+					}
+				}
+			}
+			for key, value := range foundMutatedFiles {
+				Expect(value).To(BeTrue(), fmt.Sprintf("Expect %s to be true, but it was false", key))
+			}
+
 		})
 
 		Context("when the image has already been unpacked", func() {

--- a/tarstream/tarstream.go
+++ b/tarstream/tarstream.go
@@ -4,12 +4,21 @@ import (
 	"bufio"
 	"bytes"
 	"io"
+	"os"
+	"path/filepath"
 
 	"archive/tar"
 
 	winio "github.com/Microsoft/go-winio"
 	"github.com/Microsoft/go-winio/backuptar"
 )
+
+var mutatedFiles = map[string]string{
+	"UtilityVM/Files/EFI/Microsoft/Boot/BCD":      "bcd.bak",
+	"UtilityVM/Files/EFI/Microsoft/Boot/BCD.LOG":  "bcd.log.bak",
+	"UtilityVM/Files/EFI/Microsoft/Boot/BCD.LOG1": "bcd.log1.bak",
+	"UtilityVM/Files/EFI/Microsoft/Boot/BCD.LOG2": "bcd.log2.bak",
+}
 
 type Streamer struct {
 	r   *tar.Reader
@@ -35,15 +44,37 @@ func (s *Streamer) FileInfoFromHeader(hdr *tar.Header) (string, int64, *winio.Fi
 	return backuptar.FileInfoFromHeader(hdr)
 }
 
-func (s *Streamer) WriteBackupStreamFromTarFile(w io.Writer, hdr *tar.Header) (*tar.Header, error) {
-	s.buf.Reset(w)
-	hdr, err := backuptar.WriteBackupStreamFromTarFile(s.buf, s.r, hdr)
-	if err != nil {
-		return nil, err
+func (s *Streamer) WriteBackupStreamFromTarFile(w io.Writer, hdr *tar.Header, layerPath string) (nextHdr *tar.Header, err error) {
+	var backupFile *os.File
+	var backupWriter *winio.BackupFileWriter
+	if backupPath, ok := mutatedFiles[hdr.Name]; ok {
+		backupFile, err = os.Create(filepath.Join(layerPath, backupPath))
+		if err != nil {
+			return nil, err
+		}
+		defer func() {
+			cerr := backupFile.Close()
+			if err == nil {
+				err = cerr
+			}
+		}()
+		backupWriter = winio.NewBackupFileWriter(backupFile, false)
+		defer func() {
+			cerr := backupWriter.Close()
+			if err == nil {
+				err = cerr
+			}
+		}()
+		s.buf.Reset(io.MultiWriter(w, backupWriter))
+	} else {
+		s.buf.Reset(w)
 	}
 
-	if err := s.buf.Flush(); err != nil {
-		return nil, err
-	}
-	return hdr, nil
+	defer func() {
+		if ferr := s.buf.Flush(); ferr != nil {
+			err = ferr
+		}
+	}()
+
+	return backuptar.WriteBackupStreamFromTarFile(s.buf, s.r, hdr)
 }


### PR DESCRIPTION


- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Fixes cloudfoundry/winc-release#43

This is inline with what what containers/storage does for pulling down windows images.

Backward Compatibility
---------------
Breaking Change? **No**
