### PR TITLE
Change hard-coded image sizes to dynamic based on regularfile

### DIFF
--- a/integration/integration_suite_test.go
+++ b/integration/integration_suite_test.go
@@ -25,8 +25,9 @@ var (
 		"link",
 		"servercore",
 	}
-	ociImagesDir string
-	keepDir      bool
+	ociImagesDir   string
+	keepDir        bool
+	baseImageBytes int64
 )
 
 func TestGrootWindows(t *testing.T) {
@@ -34,6 +35,34 @@ func TestGrootWindows(t *testing.T) {
 	SetDefaultEventuallyTimeout(time.Minute)
 	SetDefaultEventuallyPollingInterval(time.Millisecond * 200)
 	RunSpecs(t, "GrootWindows Suite")
+}
+
+func setBaseImageBytes() {
+	if baseImageBytes != 0 {
+		return
+	}
+	// baseImageBytes should be set dynamically because we don't control the size of the base image from Microsoft
+	// Since the method for determining the image size is equivalent to creating it, just do that.
+	driverStore, err := os.MkdirTemp("", "base.stats.store")
+	Expect(err).ToNot(HaveOccurred())
+
+	volumeMountDir, err := os.MkdirTemp("", "base.mounted-volume")
+	Expect(err).ToNot(HaveOccurred())
+
+	imageURI := pathToOCIURI(filepath.Join(ociImagesDir, "regularfile"))
+
+	bundleID := randomBundleID()
+
+	outputSpec := grootCreate(driverStore, imageURI, bundleID)
+	mountVolume(outputSpec.Root.Path, volumeMountDir)
+	volumeStats := grootStats(driverStore, bundleID)
+	baseImageBytes = volumeStats.DiskUsage.TotalBytesUsed
+
+	unmountVolume(volumeMountDir)
+	destroyVolumeStore(driverStore)
+	destroyLayerStore(driverStore)
+	Expect(os.RemoveAll(volumeMountDir)).To(Succeed())
+	Expect(os.RemoveAll(driverStore)).To(Succeed())
 }
 
 var _ = SynchronizedBeforeSuite(func() []byte {

--- a/integration/stats_test.go
+++ b/integration/stats_test.go
@@ -13,8 +13,6 @@ import (
 
 var _ = Describe("Stats", func() {
 	const (
-		//NOTE: this is for 1809 version of container image
-		baseImageSizeBytes = 357566305
 		diskLimitSizeBytes = int64(500 * 1024 * 1024)
 		fileSize           = int64(30 * 1024 * 1024)
 	)
@@ -37,6 +35,8 @@ var _ = Describe("Stats", func() {
 		imageURI = pathToOCIURI(filepath.Join(ociImagesDir, "regularfile"))
 
 		bundleID = randomBundleID()
+
+		setBaseImageBytes()
 	})
 
 	AfterEach(func() {
@@ -55,7 +55,7 @@ var _ = Describe("Stats", func() {
 
 		It("reports the image stats", func() {
 			volumeStats := grootStats(driverStore, bundleID)
-			Expect(volumeStats.DiskUsage.TotalBytesUsed).To(BeNumerically("~", baseImageSizeBytes, 7*1024))
+			Expect(volumeStats.DiskUsage.TotalBytesUsed).To(BeNumerically("~", baseImageBytes, 7*1024))
 			Expect(volumeStats.DiskUsage.ExclusiveBytesUsed).To(BeNumerically("~", 0, 7*1024))
 		})
 
@@ -67,7 +67,7 @@ var _ = Describe("Stats", func() {
 
 			It("includes the file in disk usage", func() {
 				volumeStats := grootStats(driverStore, bundleID)
-				Expect(volumeStats.DiskUsage.TotalBytesUsed).To(BeNumerically("~", baseImageSizeBytes+fileSize, 7*1024))
+				Expect(volumeStats.DiskUsage.TotalBytesUsed).To(BeNumerically("~", baseImageBytes+fileSize, 7*1024))
 				Expect(volumeStats.DiskUsage.ExclusiveBytesUsed).To(BeNumerically("~", fileSize, 7*1024))
 			})
 		})
@@ -84,7 +84,7 @@ var _ = Describe("Stats", func() {
 
 		It("returns just the base image size", func() {
 			volumeStats := grootStats(driverStore, bundleID)
-			Expect(volumeStats.DiskUsage.TotalBytesUsed).To(BeNumerically("~", baseImageSizeBytes, 7*1024))
+			Expect(volumeStats.DiskUsage.TotalBytesUsed).To(BeNumerically("~", baseImageBytes, 7*1024))
 			Expect(volumeStats.DiskUsage.ExclusiveBytesUsed).To(BeNumerically("~", 0, 7*1024))
 		})
 	})


### PR DESCRIPTION
- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
We're using some hard-coded image sizes in our tests.  When Microsoft updates their `nanoserver` image it breaks our pipeline until we update the hard-coded value.  To prevent this, we're going to use the `regularfile` image size as our base because in `stats_test.go` we're testing `ExclusiveBytesUsed` and expecting it to be approximately 0, which is good enough for our testing.


Backward Compatibility
---------------
Breaking Change? **No**